### PR TITLE
Rename and tidy-up the deform bones option

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -23,7 +23,7 @@ bl_info = {
     "name": "OpenMW Collada Exporter",
     "author": "OpenMW community, Godot Engine team",
     "version": (1, 10, 11),
-    "blender": (2, 83, 0),
+    "blender": (2, 93, 0),
     "api": 38691,
     "location": "File > Import-Export",
     "description": ("Export models in Collada format to OpenMW "),
@@ -108,10 +108,9 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         default=True,
         )
         
-    use_exclude_ctrl_bones : BoolProperty(
-        name="Exclude Control Bones",
-        description=("Exclude skeleton bones with names beginning with 'ctrl' "
-                     "or bones which are not marked as Deform bones."),
+    use_armature_deform_only : BoolProperty(
+        name="Only Deform Bones",
+        description=("Only export bones which are enabled to deform geometry"),
         default=True,
         )
         
@@ -318,7 +317,7 @@ class DAE_PT_export_armature(bpy.types.Panel):
         operator = sfile.active_operator
         
         col = layout.column(align = True)
-        col.prop(operator, 'use_exclude_ctrl_bones')
+        col.prop(operator, 'use_armature_deform_only')
         
 class DAE_PT_export_animation(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'


### PR DESCRIPTION
- Makes the option the same as with other Blender exporters (glftf, fbx)
- Don't look for the "ctrl" prefix as it's a limited way to decide which bones deform the geometry. All use cases are covered with the Deform flag anyway and should be used instead.

![only_def_bones](https://user-images.githubusercontent.com/3763179/153308192-e0e722c1-80c3-4ffe-b16c-f51749726889.png)
