### PR TITLE
Option to export animations based on NLA strips.

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -124,7 +124,7 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         name="All Actions",
         description=("Export all actions for the first armature found "
                      "in separate DAE files"),
-        default=True,
+        default=False,
         )
         
     use_anim_skip_noexp : BoolProperty(
@@ -173,7 +173,22 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         description=("Export a textkeys file based on timeline markers."
                      " Needed to define animations for OpenMW."),
         default=False,
-        )    
+        )
+        
+    anim_source : EnumProperty(
+        name="Animation Source",
+        items=(("SCENE", "Timeline",
+                "Export global scene animation as a single animation clip"),
+               ("ACTIONS", "Actions",
+               "Export each action as its own animation clip"),
+               ("NLA_STRIPS", "NLA Strips",
+               "Export each un-muted NLA strip as its own animation clip"),
+               ),
+        description=(
+            'Animation data used to create animation clips\n'
+            'in the exported COLLADA file'),
+        default="SCENE",
+        )
 
     use_limit_precision : IntProperty(
         name="Data Precision",
@@ -206,7 +221,7 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         pass
 
 def menu_func(self, context):
-    self.layout.operator(CE_OT_export_dae.bl_idname, text="Better Collada (.dae)")
+    self.layout.operator(CE_OT_export_dae.bl_idname, text="OpenMW Collada (.dae)")
 
 class DAE_PT_export_include(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -345,15 +360,17 @@ class DAE_PT_export_animation(bpy.types.Panel):
         layout.use_property_decorate = False
         
         sfile = context.space_data
-        operator = sfile.active_operator
-        
-        layout.enabled = operator.use_anim     
+        operator = sfile.active_operator        
+
+        layout.enabled = operator.use_anim
+        layout.prop(operator, 'anim_source', text="Source")
         col = layout.column(align = True)
-        col.prop(operator, 'use_anim_action_all')
-        col.prop(operator, 'use_anim_skip_noexp')
+        if operator.anim_source == "ACTIONS":
+            col.prop(operator, 'use_anim_skip_noexp')
         col.prop(operator, 'use_anim_optimize')
         col.prop(operator, 'anim_optimize_precision')
- 
+
+
 class DAE_PT_export_extras(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'


### PR DESCRIPTION
Adds an option to export animations based on animation strips in Blender's NLA editor.

OpenMW requires individual exported animations to not overlap one another in the frame range. Current workflow was where for each action the keys were offset manually. This is an unorthodox approach and somewhat clunky to work with. If a single action was changed (became longer, shorter), all of the following actions would need to be adjusted manually. Not something to make animators happy. https://openmw.readthedocs.io/en/latest/reference/modding/custom-models/pipeline-blender-collada.html#animations

What this enables is to normally work with each action starting from frame 1 and not care where other actions are in the frame range. Afterwards they are all added to the NLA editor as seen on the image below and are exported as required. Each strip in the NLA editor is a container for an action and the exported result takes into account the scale, position, repetition, frame range, and naming of NLA strips.

![anim_from_nla](https://user-images.githubusercontent.com/3763179/153468880-55276df6-3c3d-410f-b473-0cad9465724d.png)

Exporter UI was changed so it's now also more apparent what source will be used to create the exported animations.

![anim_from_nla_ui](https://user-images.githubusercontent.com/3763179/153470465-13f81b03-8551-41c5-a30b-3c8389635c4f.png)

This works only when there is a single armature / rig being exported. The general animation workflow I'm familiar with never goes into including multiple armatures / rigs in a single file, so this limitation shouldn't hinder any sane workflow anyway.