### PR TITLE
Skinned Body Part XML Description

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -117,8 +117,9 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
     use_bodypart_description : BoolProperty(
         name="Skinned Body Part",
         description=("Required by OpenMW to know this is an armature of a "
-                    "skinned body part. Rigid body parts without armature "
-                    "deformations should leave it disabled"),
+                    "skinned body part. Leave disabled for:\n"
+                    "- Rigid body parts without armature deformations\n"
+                    "- Animated meshes not used as body parts in OpenMW"),
         default=False,
         )
         

--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -114,6 +114,14 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         default=True,
         )
         
+    use_bodypart_description : BoolProperty(
+        name="Skinned Body Part",
+        description=("Required by OpenMW to know this is an armature of a "
+                    "skinned body part. Rigid body parts without armature "
+                    "deformations should leave it disabled"),
+        default=False,
+        )
+        
     use_anim : BoolProperty(
         name="Export Animation",
         description="Export keyframe animation",
@@ -333,6 +341,7 @@ class DAE_PT_export_armature(bpy.types.Panel):
         
         col = layout.column(align = True)
         col.prop(operator, 'use_armature_deform_only')
+        col.prop(operator, 'use_bodypart_description')
         
 class DAE_PT_export_animation(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1410,6 +1410,21 @@ class DaeExporter:
         self.writel(S_NODES, 5, "</Descriptions>")
         self.writel(S_NODES, 4, "</technique>")
         self.writel(S_NODES, 3, "</extra>")
+    
+    def export_description_bodypart(self):
+        """
+        Description required by OpenMW to properly assign skinned body parts
+        from separate files to a single armature belonging to a character.
+        In this case the existing armature of the skinned body part needs
+        to be discarded.
+        """
+        self.writel(S_NODES, 3, "<extra type=\"Node\">")
+        self.writel(S_NODES, 4, "<technique profile=\"OpenSceneGraph\">")
+        self.writel(S_NODES, 5, "<Descriptions>")
+        self.writel(S_NODES, 5, "<Description>bodypart</Description>")
+        self.writel(S_NODES, 5, "</Descriptions>")
+        self.writel(S_NODES, 4, "</technique>")
+        self.writel(S_NODES, 3, "</extra>")
 
     def export_curve(self, curve):
         splineid = self.new_id("spline")
@@ -1620,22 +1635,9 @@ class DaeExporter:
         for x in sorted(node.children, key=lambda x: x.name):
             self.export_node(x, il)
         
-        if (self.config["use_bodypart_description"]
-            and node.type == "ARMATURE"
-            and not node.parent):
-            """
-            Description required by OpenMW to properly assign skinned body parts
-            from separate files to a single armature belonging to a character.
-            In this case the existing armature of the skinned body part needs
-            to be discarded.
-            """
-            self.writel(S_NODES, 3, "<extra type=\"Node\">")
-            self.writel(S_NODES, 4, "<technique profile=\"OpenSceneGraph\">")
-            self.writel(S_NODES, 5, "<Descriptions>")
-            self.writel(S_NODES, 5, "<Description>bodypart</Description>")
-            self.writel(S_NODES, 5, "</Descriptions>")
-            self.writel(S_NODES, 4, "</technique>")
-            self.writel(S_NODES, 3, "</extra>")
+        if (self.config["use_bodypart_description"] and
+            node.type == "ARMATURE" and not node.parent):
+            self.export_description_bodypart()
         
         il -= 1
         self.writel(S_NODES, il, "</node>")

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1619,7 +1619,24 @@ class DaeExporter:
 
         for x in sorted(node.children, key=lambda x: x.name):
             self.export_node(x, il)
-
+        
+        if (self.config["use_bodypart_description"]
+            and node.type == "ARMATURE"
+            and not node.parent):
+            """
+            Description required by OpenMW to properly assign skinned body parts
+            from separate files to a single armature belonging to a character.
+            In this case the existing armature of the skinned body part needs
+            to be discarded.
+            """
+            self.writel(S_NODES, 3, "<extra type=\"Node\">")
+            self.writel(S_NODES, 4, "<technique profile=\"OpenSceneGraph\">")
+            self.writel(S_NODES, 5, "<Descriptions>")
+            self.writel(S_NODES, 5, "<Description>bodypart</Description>")
+            self.writel(S_NODES, 5, "</Descriptions>")
+            self.writel(S_NODES, 4, "</technique>")
+            self.writel(S_NODES, 3, "</extra>")
+        
         il -= 1
         self.writel(S_NODES, il, "</node>")
         bpy.context.view_layer.objects.active = prev_node


### PR DESCRIPTION
With COLLADA and OpenMW, when a skinned mesh is used as a body part, it is assigned to a character's main skeleton. The initial skeleton included in the body part file needs to be discarded. OpenMW recognizes it when the following description is included under the armature node in the XML.

```
<extra type="Node">
    <technique profile="OpenSceneGraph">
        <Descriptions>
        <Description>bodypart</Description>
        </Descriptions>
    </technique>
</extra>
```
Solves https://github.com/OpenMW/collada-exporter/issues/13

ToDo: move the description in its own function, figure out whether there's a better place in the UI to place the toggle.